### PR TITLE
fix: changelog generation

### DIFF
--- a/.github/workflows/changelog.yml
+++ b/.github/workflows/changelog.yml
@@ -20,7 +20,13 @@ jobs:
           token: ${{ secrets.GH_TOKEN }}
           config_file: .github/tag-changelog-config.js
           exclude_types: other,doc,chore
-          changelog: CHANGELOG.md
+
+      - name: Prepend Changelog
+        uses: endaft/action-prepend@v0.0.7
+        with:
+          file_target: CHANGELOG.md
+          value_in: ${{ format('{0}\n', steps.changelog.outputs.changelog) }}
+          is_file: "false"
 
       - name: Create release
         uses: actions/create-release@latest


### PR DESCRIPTION
Incorrect parameter in the job for generating changelog. The output needs to be used by another action `endaft/action-prepend@v0.0.7`